### PR TITLE
Remove specifics `copts` from my machine

### DIFF
--- a/examples/bazel_workspace_commands_targets/.bazelrc
+++ b/examples/bazel_workspace_commands_targets/.bazelrc
@@ -28,5 +28,3 @@
 # - Check out the official documentation `https://bazel.build/run/bazelrc` for more details.
 
 common --lockfile_mode=off # Ideally you want to use a lockfile, but for this example we disable it for simplicity.
-
-build --copt='-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1'


### PR DESCRIPTION
This change supports bazel-basics-part-2.